### PR TITLE
Fix unnecessary escaping of From at start of line

### DIFF
--- a/stump/bin/processApproved
+++ b/stump/bin/processApproved
@@ -41,7 +41,7 @@ post() {
     # lines in the added headers.
 
     cat $TMPFILE					\
-      | formail -f -a "Newsgroups: $NEWSGROUP"		\
+      | formail -b -f -a "Newsgroups: $NEWSGROUP"	\
 	    -I Path:					\
             -I X-Moderate-For:                          \
             -I Return-Path:                             \

--- a/stump/bin/processRejected
+++ b/stump/bin/processRejected
@@ -29,7 +29,7 @@ reply() {
     if [ "x$WEBSTUMP_MESSAGENUM" != x ]; then
         eventheader="[$WEBSTUMP_MESSAGENUM] $eventheader"
     fi
-    cat $MESSAGE | formail -rt -I "Reply-To: $BOARD" 	\
+    cat $MESSAGE | formail -brt -I "Reply-To: $BOARD" 	\
 			       -I "Errors-To: $MUNGED_ADDRESS"	 \
         -I "X-Webstump-Event: $eventheader" \
 	$MAILOUT_REJECT_FORMAIL_ARGS

--- a/stump/bin/submission.pl
+++ b/stump/bin/submission.pl
@@ -50,7 +50,7 @@ $Newsgroup = $ENV{'NEWSGROUP'};
 $TmpFile = "$ENV{'TMP'}/submission.$$";
 
 # how do we treat suspicious articles?
-$Command_Suspicious = "formail -a \"Newsgroups: $Newsgroup\" " .
+$Command_Suspicious = "formail -b -a \"Newsgroups: $Newsgroup\" " .
                       "| stump.pl suspicious.pl";
 
 # approved

--- a/stump/etc/modack.approved.INO
+++ b/stump/etc/modack.approved.INO
@@ -10,7 +10,7 @@ fi
 input="$1"
 
 (
-  formail <"$input" -rt -I "Reply-To: $NOACK"	\
+  formail <"$input" -brt -I "Reply-To: $NOACK"	\
 	        -I "X-Webstump-Event: approve"	\
 		$MAILOUT_ACCEPTACK_FORMAIL_ARGS
   cat <<_EOB_

--- a/stump/etc/modack.received.INO
+++ b/stump/etc/modack.received.INO
@@ -8,7 +8,7 @@ TMPFILE=$TMP/reply.$$
 cat > $TMPFILE
 
 (
-  formail -rt -I "Reply-To: $NOACK" \
+  formail -brt -I "Reply-To: $NOACK" \
         -I "X-Webstump-Event: ack" \
 	$MAILOUT_RECVACK_FORMAIL_ARGS \
      < $TMPFILE


### PR DESCRIPTION
Added the -b options to formail in various places so that it does not
apply the mbox escaping convention to lines starting 'From '.

Closes #2 