### PR TITLE
Watch

### DIFF
--- a/webstump/doc/help/filter-lists.html
+++ b/webstump/doc/help/filter-lists.html
@@ -35,6 +35,9 @@ The algorithm for every incoming article is as follows:
   <LI> File message for human review if the article contains words from <A
        HREF=##watch.words.list>the List of Suspicious Words</A>.
 
+  <LI> File message for human review if the article contains words from <A
+       HREF=##watch.unquoted.words.list>the List of Suspicious Words when not Quoted</A>.
+
   <LI> Approve message if the author is listed in <A
        HREF=##good.posters.list>the List of Preapproved Posters</A>.
 

--- a/webstump/doc/help/watch.unquoted.words.list.html
+++ b/webstump/doc/help/watch.unquoted.words.list.html
@@ -1,0 +1,19 @@
+<p>List of words to watch is the list of text patterns 
+which, if they appear in a message, should ensure that the message is
+not automatically approved and is stored in WebSTUMP for human review
+unless they appear in text quoted from a previously approved posting</p>
+
+<p>These words may be an indication of a potential spam, or a flame
+etc. Perhaps, for many groups, putting common profanities, as well
+as things like XXX and 1-900, is a good strategy. Note however, that
+there is generally no reason to forbid the use of profanity, as such.</p>>
+
+<p>Example:</p>>
+
+<PRE>
+bonehead
+dickhead
+</PRE>
+
+<p>My advice is to watch your group for patterns appearing in offtopic posts,
+and use them to your advantage to help you with filtering.</p>

--- a/webstump/scripts/filter.lib.pl
+++ b/webstump/scripts/filter.lib.pl
@@ -267,8 +267,8 @@ print STDERR "Filing Article for review because article matches '$match'\n";
     return; # file message
   }
 
-  if( my @matches = &name_is_in_list_unquoted( $message, $newsgroup, "watch.unquoted.words.list" ) ) {
-    my $match = join(',', @matches);
+  my @matches = &name_is_in_list_unquoted( $message, $newsgroup, "watch.unquoted.words.list" );
+  if( my $match = join(',', @matches) ) {
     &append_to_file( $warning_file, "Warning: article matches '$match' from the list of suspicious words outside a quote from an approved article.\n" );
 print STDERR "Filing Article for review because article matches '$match' unquoted\n";
     &append_to_file( $highlight_file, join("\n", @matches));

--- a/webstump/scripts/filter.lib.pl
+++ b/webstump/scripts/filter.lib.pl
@@ -137,9 +137,7 @@ sub name_is_in_list_unquoted {
       $unquoted{$k} = 1;
     }
   }
-  my $Result = join(',', sort(keys(%unquoted)));
-  return $Result ;
-
+  return sort(keys(%unquoted));
 }
 
 ######################################################################
@@ -246,6 +244,7 @@ sub review_incoming_message { # Newsgroup, From, Subject, RealSubject, Message, 
   }
 
   my $warning_file = &article_file_name( $dir ) . "/stump-warning.txt";
+  my $highlight_file = &article_file_name( $dir ) . "/stump-highlight.txt";
   my $match;
 
   $ignore_demo_mode = 1;
@@ -268,9 +267,11 @@ print STDERR "Filing Article for review because article matches '$match'\n";
     return; # file message
   }
 
-  if( $match = &name_is_in_list_unquoted( $message, $newsgroup, "watch.unquoted.words.list" ) ) {
+  if( my @matches = &name_is_in_list_unquoted( $message, $newsgroup, "watch.unquoted.words.list" ) ) {
+    my $match = join(',', @matches);
     &append_to_file( $warning_file, "Warning: article matches '$match' from the list of suspicious words outside a quote from an approved article.\n" );
 print STDERR "Filing Article for review because article matches '$match' unquoted\n";
+    &append_to_file( $highlight_file, join("\n", @matches));
     return; # file message
   }
 

--- a/webstump/scripts/html_output.pl
+++ b/webstump/scripts/html_output.pl
@@ -772,6 +772,7 @@ sub html_newsgroup_management {
     <OPTION VALUE=watch.subjects.list>Suspicious Subjects List
     <OPTION VALUE=bad.subjects.list>Banned Subjects List
     <OPTION VALUE=watch.words.list>Suspicious Words List
+    <OPTION VALUE=watch.unquoted.words.list>Suspicious Unquoted Words List
     <OPTION VALUE=bad.words.list>Banned Words List
 
   </SELECT>

--- a/webstump/scripts/webstump.lib.pl
+++ b/webstump/scripts/webstump.lib.pl
@@ -403,7 +403,8 @@ sub check_config_list {
         && $list_to_edit ne "watch.subjects.list"
         && $list_to_edit ne "bad.subjects.list"
         && $list_to_edit ne "bad.words.list"
-        && $list_to_edit ne "watch.words.list" );
+        && $list_to_edit ne "watch.words.list"
+        && $list_to_edit ne "watch.unquoted.words.list" );
 
   return &untaint( $list_to_edit );
 }


### PR DESCRIPTION
Fixes #4 
This adds an additional watched words list where matches that occur in lines quoted from an approved message are ignored. It also adds highlighting of the matched words in that new list.

If this works and is useful in a live system then the highlighting can be extended to work for the original watched words list.